### PR TITLE
Use maxLevel constant instead of hard coded value

### DIFF
--- a/components/LevelThermometer.js
+++ b/components/LevelThermometer.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as d3 from 'd3'
-import { pointsToLevels, categoryPointsFromMilestoneMap, categoryColorScale, categoryIds } from '../constants'
+import { pointsToLevels, categoryPointsFromMilestoneMap, categoryColorScale, categoryIds, maxLevel } from '../constants'
 import React from 'react'
 import type { MilestoneMap } from '../constants'
 
@@ -29,7 +29,7 @@ class LevelThermometer extends React.Component<Props> {
     super(props)
 
     this.pointScale = d3.scaleLinear()
-      .domain([0, 135])
+      .domain([0, maxLevel])
       .rangeRound([0, width - margins.left - margins.right]);
 
     this.topAxisFn = d3.axisTop()

--- a/components/PointSummaries.js
+++ b/components/PointSummaries.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { pointsToLevels, milestoneToPoints, trackIds, totalPointsFromMilestoneMap } from '../constants'
+import { pointsToLevels, milestoneToPoints, trackIds, totalPointsFromMilestoneMap, maxLevel } from '../constants'
 import type { MilestoneMap } from '../constants'
 import React from 'react'
 
@@ -22,7 +22,7 @@ class PointSummaries extends React.Component<Props> {
     let pointsToNextLevel = 1
     while (!(nextLevel = pointsToLevels[totalPoints + pointsToNextLevel])) {
       pointsToNextLevel++
-      if (pointsToNextLevel > 135) {
+      if (pointsToNextLevel > maxLevel) {
         pointsToNextLevel = 'N/A'
         break
       }


### PR DESCRIPTION
Fixes #41 

This fix updates both instances of a hard coded max level value to instead reference the `maxLevel` constant set in `constants.js`.

## Before Fix
<img width="568" alt="screen shot 2018-07-09 at 12 10 12 pm" src="https://user-images.githubusercontent.com/407398/42465511-cb9f6c44-8371-11e8-9192-f9fcc4c0ebf2.png">

## After Fix
<img width="582" alt="screen shot 2018-07-09 at 12 15 02 pm" src="https://user-images.githubusercontent.com/407398/42465497-be36022a-8371-11e8-97e7-3b7c3dfa601e.png">
